### PR TITLE
ImageID Search

### DIFF
--- a/cmd/hub-quay-agent/main.go
+++ b/cmd/hub-quay-agent/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	release = "v0.0.6"
+	release = "v0.0.7"
 )
 
 func init() {

--- a/pkg/client/repositories.go
+++ b/pkg/client/repositories.go
@@ -63,10 +63,8 @@ func (r *repositoryImpl) Create(ctx context.Context, repo *NewRepo) error {
 	return r.Handle(ctx, http.MethodPost, "/repository", &repo, nil)
 }
 
-// ImageAnalysis returns the image scan for a particular image tag
-func (r *repositoryImpl) ImageAnalysis(ctx context.Context, name, tag string) (*ImageAnalysis, error) {
-	scan := &ImageAnalysis{}
-
+// ImageAnalysisByTag returns the image scan for a particular image tag
+func (r *repositoryImpl) ImageAnalysisByTag(ctx context.Context, name, tag string) (*ImageAnalysis, error) {
 	// @step: check we have the tag
 	reference, err := r.GetTag(ctx, name, tag)
 	if err != nil {
@@ -76,7 +74,14 @@ func (r *repositoryImpl) ImageAnalysis(ctx context.Context, name, tag string) (*
 		return nil, errors.New("image tag does not exist")
 	}
 
-	uri := fmt.Sprintf("/repository/%s/image/%s/security?vulnerabilities=true", name, reference.ImageID)
+	return r.ImageAnalysisByImageID(ctx, name, reference.ImageID)
+}
+
+// ImageAnalysisByImageID returns the scan from an image id
+func (r *repositoryImpl) ImageAnalysisByImageID(ctx context.Context, name, imageID string) (*ImageAnalysis, error) {
+	scan := &ImageAnalysis{}
+
+	uri := fmt.Sprintf("/repository/%s/image/%s/security?vulnerabilities=true", name, imageID)
 
 	return scan, r.Handle(ctx, http.MethodGet, uri, nil, scan)
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -49,8 +49,10 @@ type Client interface {
 
 // Repositories is the contract to the repositories
 type Repositories interface {
-	// ImageAnalysis returns the scan analysis for a specific tag
-	ImageAnalysis(context.Context, string, string) (*ImageAnalysis, error)
+	// ImageAnalysisByTag returns the scan analysis for a specific tag
+	ImageAnalysisByTag(context.Context, string, string) (*ImageAnalysis, error)
+	// ImageAnalysisByImageID returns the scan for a image id
+	ImageAnalysisByImageID(context.Context, string, string) (*ImageAnalysis, error)
 	// Create is responsible for creating a repository
 	Create(context.Context, *NewRepo) error
 	// Delete is responsible for deleting a repository

--- a/pkg/server/repositories.go
+++ b/pkg/server/repositories.go
@@ -316,7 +316,7 @@ func (s *serverImpl) GetImageAnalysis(ctx context.Context, namespace, name, tag 
 
 	// @step: retrieve the image analysis for any our tags
 	for _, x := range filtered {
-		resp, err := s.Client.Repositories().ImageAnalysis(ctx, fullname, x.Name)
+		resp, err := s.Client.Repositories().ImageAnalysisByImageID(ctx, fullname, x.ImageID)
 		if err != nil {
 			return nil, newError("retrieving the image analysis", err).model()
 		}


### PR DESCRIPTION
- removing the need to search for the image id again

```shell
[jest@starfury hub-quay-agent]$ time agent-api 'registry/calico/node/status?tag=v3.10.0-0.dev-14-g1521e7e' > /dev/null

real	0m2.856s
user	0m0.005s
sys	0m0.011s
[jest@starfury hub-quay-agent]$ time agent-api 'registry/calico/node/status?tag=v3.10.0-0.dev-14-g1521e7e' > /dev/null

real	0m1.894s
user	0m0.002s
sys	0m0.008s
```